### PR TITLE
Remove -Werror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 override CFLAGS += \
 	-std=c99 -D_XOPEN_SOURCE=700 -pedantic \
-	-Wall -Werror -Wextra \
+	-Wall -Wextra \
 	-DPROG='"$(PROG)"' -DVERSION='"$(VERSION)"'
 
 override LDLIBS += -lm


### PR DESCRIPTION
Werror is good for development, but not so good for deployment. We don't want to error whenever a compiler comes up with better diagnostics.

This came up recently with the following:

```
In file included from src/exec.c:7:
src/exec.c: In function ‘exec_set’:
src/burno.h:19:9: error: ‘fd’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   19 |         close(*fd);
      |         ^~~~~~~~~~
```